### PR TITLE
fix(1p): detect 1Password via capability probe, not op whoami

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -240,7 +240,7 @@ takes effect on subsequent reboots.
 
 A few packages are deliberately excluded from the Brewfile because
 they need SSH credentials, manual licensing, or have flaky unattended
-installs. Run these by hand once 1Password's SSH agent is active:
+installs. Run these by hand after bootstrap:
 
 ```bash
 # ExpressVPN — cask's LaunchDaemon install is historically flaky
@@ -261,8 +261,10 @@ If you use `gh`:
 gh auth login
 ```
 
-The 1Password SSH agent handles `git push` over SSH; `gh`'s HTTPS API
-calls need their own token.
+`git push`/`fetch` to GitHub over SSH uses the on-disk key files
+(`~/.ssh/id`, `~/.ssh/work_id`) — the 1Password SSH agent is bypassed for
+`github.com` and only serves other SSH hosts. `gh`'s HTTPS API calls still
+need their own token.
 
 ## 7. Optional: restart
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -272,9 +272,12 @@ Once, to ensure login items and brew services pick up cleanly.
 
 ## Troubleshooting
 
-**`op whoami` fails after restart.** The 1Password CLI session expired. Run
-`op signin` again. Chezmoi templates that read from op will fail until you
-do.
+**`op whoami` says "not signed in" / fails after restart.** With the 1Password
+app's CLI integration, `op` authenticates per-command via biometric and keeps no
+token session, so `op whoami` reports not-signed-in even though `op read` works.
+`chezmoi init`/`apply` probe with a real `op read`, so they work **without**
+`op signin`. You only need `op signin` (a token session) for `bootstrap.sh`'s
+preflight on a fresh machine, or if you've turned the app integration off.
 
 **`chezmoi apply` says "recipient mismatch" for age.** The public key
 embedded in `.chezmoi.toml.tmpl` doesn't match the private key in 1Password.

--- a/SETUP.md
+++ b/SETUP.md
@@ -103,6 +103,12 @@ op signin
 
 Then proceed.
 
+> **Why a token session here but not for daily use?** `bootstrap.sh`'s
+> preflight gates on `op whoami`, which needs a token session. Day-to-day,
+> `chezmoi init`/`apply` detect 1Password with an `op read` capability probe and
+> do **not** need `op signin` (see Troubleshooting → *`op whoami` says "not
+> signed in"*).
+
 ### Run
 
 ```bash

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -119,6 +119,17 @@ and leave the user with two `op` binaries on PATH, where only one
 holds the CLI-integration entitlement. The symptom is cryptic:
 `op whoami` reports signed in but `onepasswordRead` templates fail.
 
+### `op whoami` says "not signed in" but `op read` works
+
+With CLI integration enabled (above), `op` authenticates per-command via the
+app's biometric prompt and keeps **no token session**, so `op whoami` reports
+"account is not signed in" even though `op read` / `onepasswordRead` succeed.
+chezmoi's config template (`home/.chezmoi.toml.tmpl`) therefore probes 1Password
+with a real `op read`, not `op whoami`, and `dots doctor` falls back the same
+way. You do **not** need `op signin` for `chezmoi init`/`apply` under
+integration; `op signin` (a token session) is only required by `bootstrap.sh`'s
+preflight on a fresh machine.
+
 ### Age identity: on-disk cache at `~/.config/chezmoi/key.txt`
 
 chezmoi's `[age]` config requires an identity **file path** —

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -7,21 +7,29 @@
 {{-   end -}}
 {{- end -}}
 
-{{/* 1Password availability: `op` must be in PATH AND authenticated.
-     We probe via `op whoami` rather than an env var gate so this works
-     on a fresh machine without relying on shell-profile bootstrapping. */}}
+{{/* 1Password availability: probe with a real `op read`, NOT `op whoami`. With
+     the 1Password app's CLI integration, `op whoami` reports "not signed in"
+     whenever no token session is cached -- even though `op read` works via a
+     biometric prompt. The old whoami gate therefore disabled 1Password
+     (encryption + all data) until you ran `op signin`. This capability probe
+     matches how the rest of the dotfiles use `onepasswordRead` (ungated). It
+     reads the age-key entry (needed just below anyway), so op-availability is
+     coupled to that entry: if "Personal/Dotfiles Age Key" is renamed, ALL 1P
+     data falls back to empty, not just encryption. An empty probe is the
+     graceful fallback (fresh machine / op missing / entry renamed). Caveat:
+     like every `onepasswordRead` here, an interactive run may prompt for
+     biometric; a headless run with no cached session blocks on that prompt. */}}
 {{- $opSignedIn := false -}}
 {{- if lookPath "op" -}}
-{{-   $whoami := output "sh" "-c" "op whoami 2>/dev/null || true" | trim -}}
-{{-   if $whoami -}}
+{{-   $opProbe := output "sh" "-c" "op read 'op://Personal/Dotfiles Age Key/notesPlain' >/dev/null 2>&1 && echo ok || true" | trim -}}
+{{-   if eq $opProbe "ok" -}}
 {{-     $opSignedIn = true -}}
 {{-   end -}}
 {{- end -}}
 
-{{/* Derive the age recipient (public key) by reading the 1Password-backed
-     identity and piping through age-keygen -y. Falls back to empty string if
-     anything fails (op not signed in, age-keygen missing, entry renamed) — in
-     which case encryption is skipped and encrypted files won't decrypt. */}}
+{{/* Derive the age recipient (public key) from that same entry via age-keygen -y.
+     Empty if op can't read or age-keygen is missing -- encryption then skipped
+     and encrypted files won't decrypt. */}}
 {{- $ageRecipient := "" -}}
 {{- if $opSignedIn -}}
 {{-   $ageRecipient = output "sh" "-c" "op read 'op://Personal/Dotfiles Age Key/notesPlain' 2>/dev/null | age-keygen -y 2>/dev/null || true" | trim -}}

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -7,34 +7,25 @@
 {{-   end -}}
 {{- end -}}
 
-{{/* 1Password availability: probe with a real `op read`, NOT `op whoami`. With
-     the 1Password app's CLI integration, `op whoami` reports "not signed in"
-     whenever no token session is cached -- even though `op read` works via a
-     biometric prompt. The old whoami gate therefore disabled 1Password
-     (encryption + all data) until you ran `op signin`. This capability probe
-     matches how the rest of the dotfiles use `onepasswordRead` (ungated). It
-     reads the age-key entry (needed just below anyway), so op-availability is
-     coupled to that entry: if "Personal/Dotfiles Age Key" is renamed, ALL 1P
-     data falls back to empty, not just encryption. An empty probe is the
-     graceful fallback (fresh machine / op missing / entry renamed). Caveat:
-     like every `onepasswordRead` here, an interactive run may prompt for
-     biometric; a headless run with no cached session blocks on that prompt. */}}
-{{- $opSignedIn := false -}}
-{{- if lookPath "op" -}}
-{{-   $opProbe := output "sh" "-c" "op read 'op://Personal/Dotfiles Age Key/notesPlain' >/dev/null 2>&1 && echo ok || true" | trim -}}
-{{-   if eq $opProbe "ok" -}}
-{{-     $opSignedIn = true -}}
-{{-   end -}}
-{{- end -}}
-
-{{/* Derive the age recipient (public key) from that same entry via age-keygen -y.
-     Empty if op can't read or age-keygen is missing -- encryption then skipped
-     and encrypted files won't decrypt. */}}
+{{/* 1Password + age availability: derive the age recipient with a SINGLE real
+     `op read`, NOT `op whoami`. Under the 1Password app's CLI integration
+     `op whoami` reports "not signed in" with no cached session even though
+     `op read` works via a biometric prompt, so the old whoami gate disabled
+     1Password (encryption + all data) until you ran `op signin`. The read is
+     piped straight through `age-keygen -y`, so only the PUBLIC recipient is ever
+     captured -- never the raw secret. A non-empty recipient means op is
+     reachable: enable encryption + 1P data. Empty is the graceful fallback
+     (fresh machine, op missing, age-keygen missing, or "Personal/Dotfiles Age
+     Key" renamed) -- note this couples ALL 1P data to that one entry + age-keygen,
+     which are required infra here anyway. Caveat: like every `onepasswordRead`
+     here, an interactive run may prompt for biometric; a headless run with no
+     cached session blocks on that prompt. */}}
 {{- $ageRecipient := "" -}}
-{{- if $opSignedIn -}}
+{{- if lookPath "op" -}}
 {{-   $ageRecipient = output "sh" "-c" "op read 'op://Personal/Dotfiles Age Key/notesPlain' 2>/dev/null | age-keygen -y 2>/dev/null || true" | trim -}}
 {{- end -}}
-{{- $ageAvailable := ne $ageRecipient "" -}}
+{{- $opAvailable := ne $ageRecipient "" -}}
+{{- $ageAvailable := $opAvailable -}}
 
 {{- if $ageAvailable }}
 encryption = "age"
@@ -52,7 +43,7 @@ recipient = {{ $ageRecipient | quote }}
 [data]
 brew_prefix = {{ $brew_prefix | quote }}
 ageAvailable = {{ $ageAvailable }}
-{{- if $opSignedIn }}
+{{- if $opAvailable }}
 ssh_key = "{{- onepasswordRead "op://Personal/4ytcjbe2ui6iz5sjfe7fn54jea/public_key" -}}"
 work_ssh_key = "{{- onepasswordRead "op://Personal/orsplwhcmkbfmxdwbf6udvpjvu/public_key" -}}"
 work_email = "{{- onepasswordRead "op://Personal/orsplwhcmkbfmxdwbf6udvpjvu/email" -}}"

--- a/home/bin/executable_dots
+++ b/home/bin/executable_dots
@@ -236,8 +236,10 @@ cmd_doctor() {
   if command -v op >/dev/null 2>&1; then
     if op whoami >/dev/null 2>&1; then
       log_ok "1Password CLI signed in ($(op whoami 2>/dev/null | awk '/^Email:/ {print $2}'))"
+    elif op read 'op://Personal/Dotfiles Age Key/notesPlain' >/dev/null 2>&1; then
+      log_ok "1Password CLI available via app integration (no token session)"
     else
-      log_warn "1Password CLI installed but not signed in (run 'op signin')"
+      log_warn "1Password CLI installed but not reachable (unlock 1Password, or run 'op signin')"
       fail=1
     fi
   else


### PR DESCRIPTION
## Why
Under the 1Password app's CLI integration, `op whoami` reports "not signed in" whenever no token session is cached — even though `op read` works fine via biometric. The config template gated encryption + **all** 1P data on that `op whoami` check, so a routine `chezmoi init` silently dropped encryption and emptied the 1P data unless you'd run `op signin` first. That then broke `chezmoi apply` (`encryption not configured` → couldn't decrypt the work git config). Surfaced during M5 setup.

## Fix
- **`home/.chezmoi.toml.tmpl`** — probe via a real `op read` of the age-key entry, matching how the rest of the dotfiles already use `onepasswordRead` (ungated). Same downstream vars (`$opSignedIn`, `$ageRecipient`, `$ageAvailable`); only *detection* changed, so the emitted TOML is structurally identical.
- **`home/bin/executable_dots`** — `dots doctor` falls back to a capability check so it stops falsely reporting "not signed in" under integration.
- **`SETUP.md` / `docs/GOTCHAS.md`** — document the integration behavior; clarify `op signin` is only needed for `bootstrap.sh`'s preflight.
- **`bootstrap.sh`** — intentionally unchanged; its one-time `op whoami` gate at fresh-machine setup is reasonable.

## Also in this PR (commit 2)
Corrected stale SSH-agent claims in `SETUP.md` left over from #4's on-disk-key switch: GitHub `push`/`fetch` over SSH uses `~/.ssh/id` / `~/.ssh/work_id` (1Password agent bypassed for github.com); the agent only serves other hosts.

## Verification
`chezmoi execute-template` from a shell with **no** `op` session:
- **op available** → `encryption = "age"`, `ageAvailable = true`, `onepassword_available = true`
- **op absent** (PATH without op) → clean empty fallback, no `encryption`/`[age]`, no hang