### PR TITLE
feat: 1Password SSH-scoped service token for headless remote auth

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -112,10 +112,28 @@ else
   log "fetching age identity from 1Password → ~/.config/chezmoi/key.txt"
   if ! op read 'op://Dotfiles/Dotfiles Age Key/notesPlain' \
         > "$HOME/.config/chezmoi/key.txt"; then
-    die "failed to fetch age key from 1Password (Personal vault)."
+    die "failed to fetch age key from 1Password (Dotfiles vault)."
   fi
   chmod 600 "$HOME/.config/chezmoi/key.txt"
   ok "age identity pinned"
+fi
+
+# --- 1Password service-account token (optional) → on-disk cache ---
+# Lets op/chezmoi resolve secrets headlessly over SSH (no Touch ID). The token
+# is the bootstrap credential for the Dotfiles vault, so it can't be fetched via
+# op — it's provisioned once, by hand (dot_zshenv exports it only in SSH
+# sessions). 1Password is authoritative; this 0600 file is a cache. Optional:
+# without it, local biometric still works and only remote headless op is
+# unavailable. Mirrors the age-key cache above. See docs/GOTCHAS.md.
+mkdir -p "$HOME/.config/op"
+chmod 700 "$HOME/.config/op"
+if [ -s "$HOME/.config/op/token" ]; then
+  chmod 600 "$HOME/.config/op/token"
+  ok "1Password service-account token present at ~/.config/op/token"
+else
+  warn "no 1Password service-account token at ~/.config/op/token; remote headless op unavailable."
+  warn "to enable: mint a token scoped to the Dotfiles vault, write it history-safe"
+  warn "  to ~/.config/op/token (chmod 600). See docs/GOTCHAS.md."
 fi
 
 # --- init + apply ---

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -110,7 +110,7 @@ if [ -s "$HOME/.config/chezmoi/key.txt" ]; then
   ok "age identity already present at ~/.config/chezmoi/key.txt"
 else
   log "fetching age identity from 1Password → ~/.config/chezmoi/key.txt"
-  if ! op read 'op://Personal/Dotfiles Age Key/notesPlain' \
+  if ! op read 'op://Dotfiles/Dotfiles Age Key/notesPlain' \
         > "$HOME/.config/chezmoi/key.txt"; then
     die "failed to fetch age key from 1Password (Personal vault)."
   fi

--- a/docs/ADD_AI_TOOL.md
+++ b/docs/ADD_AI_TOOL.md
@@ -41,12 +41,12 @@ check loop in `cmd_doctor`. Add `"$HOME/.newtool"` to both.
 
 For each auth/token file:
 
-1. Create a Secure Note in `Personal` named e.g. `NewTool auth`. Paste the
+1. Create a Secure Note in `Dotfiles` named e.g. `NewTool auth`. Paste the
    plaintext file contents into `notesPlain`.
 2. Replace the captured file with a `.tmpl` calling `onepasswordRead`:
 
    ```go-template
-   {{ onepasswordRead "op://Personal/NewTool auth/notesPlain" }}
+   {{ onepasswordRead "op://Dotfiles/NewTool auth/notesPlain" }}
    ```
 
 3. Delete the plaintext file from `home/dot_newtool/` before committing.

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -171,6 +171,15 @@ chezmoi's config switches to `[onepassword] mode = "service"` when the token
 is present. Local interactive runs have no token and keep biometric desktop
 integration.
 
+**Why `dots apply` runs `chezmoi apply --init`**: chezmoi bakes `[onepassword]
+mode` at config-render (`init`) time and only *reads* it on a plain `apply`.
+Because the same M5 is used both locally (no token) and over SSH (token),
+`dots apply` and `dots sync` pass `--init` so the config re-renders from the
+current session's env every run — service mode over SSH, default biometric
+locally. A bare `chezmoi apply` reuses the last-baked mode and will hard-error
+if the session changed (`account` mode + token set, or `service` mode + no
+token). Use `dots apply` (or `chezmoi apply --init`) for the auth switch.
+
 **Security posture**: same on-disk-cache model as the age key — 1Password is
 authoritative, the file is a derived cache. The token is a long-lived bearer
 (network-reachable), so scope it `read_items`-only and mint it with an

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -97,8 +97,12 @@ The fix is either:
 
 1. Use the tool from an interactive terminal where `op` works (most
    dotfiles operations are user-initiated anyway), or
-2. For truly automated flows, use a 1Password service account and
-   `OP_SERVICE_ACCOUNT_TOKEN` (not configured in this repo).
+2. For remote/headless flows, this repo configures a 1Password service
+   account: `dot_zshenv` exports `OP_SERVICE_ACCOUNT_TOKEN` (from the
+   `~/.config/op/token` cache) **only when `$SSH_CONNECTION` is set**, so
+   `op`/`chezmoi` resolve secrets headlessly over SSH while local shells stay
+   on biometric. See "1Password service-account token" below for setup +
+   rotation.
 
 ---
 
@@ -148,11 +152,42 @@ cache.
 re-run:
 
 ```bash
-op read 'op://Personal/Dotfiles Age Key/notesPlain' \
+op read 'op://Dotfiles/Dotfiles Age Key/notesPlain' \
   > ~/.config/chezmoi/key.txt
 chmod 600 ~/.config/chezmoi/key.txt
 ```
 
 If you lose the local cache (e.g., after `rm -rf ~/.config/chezmoi/`),
 re-run `bootstrap.sh` — it detects the missing file and re-fetches.
+
+### 1Password service-account token: `~/.config/op/token`
+
+Remote (SSH) sessions have no reachable Touch ID, so `op` can't
+biometric-prompt. A 1Password **service account** scoped to the read-only
+`Dotfiles` vault provides a headless path. The token lives at
+`~/.config/op/token` (`0600`); `dot_zshenv` exports it as
+`OP_SERVICE_ACCOUNT_TOKEN` **only when `$SSH_CONNECTION` is set**, and
+chezmoi's config switches to `[onepassword] mode = "service"` when the token
+is present. Local interactive runs have no token and keep biometric desktop
+integration.
+
+**Security posture**: same on-disk-cache model as the age key — 1Password is
+authoritative, the file is a derived cache. The token is a long-lived bearer
+(network-reachable), so scope it `read_items`-only and mint it with an
+`--expires-in` cadence.
+
+**Setup / rotation**: the token is the bootstrap credential, so it can't be
+`op read` — provision it by hand, history-safe (never as a command argument,
+since `dot_zshenv` enables `SAVEHIST`):
+
+```bash
+# In 1Password: mint a service-account token scoped to Dotfiles (read-only,
+# with an expiry), then write it without it touching shell history:
+read -rs OP_TOK && printf '%s' "$OP_TOK" > ~/.config/op/token && unset OP_TOK
+chmod 600 ~/.config/op/token
+```
+
+Rotate on the expiry cadence. A token that ever lands in shell history or
+logs must be **rotated**, not just deleted. `dots doctor` reports whether a
+present token actually works (validity, not just presence).
 

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -60,9 +60,9 @@ recipient = {{ $ageRecipient | quote }}
 brew_prefix = {{ $brew_prefix | quote }}
 ageAvailable = {{ $ageAvailable }}
 {{- if $opAvailable }}
-ssh_key = "{{- onepasswordRead "op://Dotfiles/4ytcjbe2ui6iz5sjfe7fn54jea/public_key" -}}"
-work_ssh_key = "{{- onepasswordRead "op://Dotfiles/orsplwhcmkbfmxdwbf6udvpjvu/public_key" -}}"
-work_email = "{{- onepasswordRead "op://Dotfiles/orsplwhcmkbfmxdwbf6udvpjvu/email" -}}"
+ssh_key = "{{- onepasswordRead "op://Dotfiles/ssh_key/public_key" -}}"
+work_ssh_key = "{{- onepasswordRead "op://Dotfiles/work_ssh_key/public_key" -}}"
+work_email = "{{- onepasswordRead "op://Dotfiles/work_ssh_key/email" -}}"
 onepassword_available = true
 {{- else }}
 ssh_key = ""

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -22,7 +22,7 @@
      cached session blocks on that prompt. */}}
 {{- $ageRecipient := "" -}}
 {{- if lookPath "op" -}}
-{{-   $ageRecipient = output "sh" "-c" "op read 'op://Personal/Dotfiles Age Key/notesPlain' 2>/dev/null | age-keygen -y 2>/dev/null || true" | trim -}}
+{{-   $ageRecipient = output "sh" "-c" "op read 'op://Dotfiles/Dotfiles Age Key/notesPlain' 2>/dev/null | age-keygen -y 2>/dev/null || true" | trim -}}
 {{- end -}}
 {{- $opAvailable := ne $ageRecipient "" -}}
 {{- $ageAvailable := $opAvailable -}}
@@ -44,9 +44,9 @@ recipient = {{ $ageRecipient | quote }}
 brew_prefix = {{ $brew_prefix | quote }}
 ageAvailable = {{ $ageAvailable }}
 {{- if $opAvailable }}
-ssh_key = "{{- onepasswordRead "op://Personal/4ytcjbe2ui6iz5sjfe7fn54jea/public_key" -}}"
-work_ssh_key = "{{- onepasswordRead "op://Personal/orsplwhcmkbfmxdwbf6udvpjvu/public_key" -}}"
-work_email = "{{- onepasswordRead "op://Personal/orsplwhcmkbfmxdwbf6udvpjvu/email" -}}"
+ssh_key = "{{- onepasswordRead "op://Dotfiles/4ytcjbe2ui6iz5sjfe7fn54jea/public_key" -}}"
+work_ssh_key = "{{- onepasswordRead "op://Dotfiles/orsplwhcmkbfmxdwbf6udvpjvu/public_key" -}}"
+work_email = "{{- onepasswordRead "op://Dotfiles/orsplwhcmkbfmxdwbf6udvpjvu/email" -}}"
 onepassword_available = true
 {{- else }}
 ssh_key = ""

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -22,10 +22,26 @@
      cached session blocks on that prompt. */}}
 {{- $ageRecipient := "" -}}
 {{- if lookPath "op" -}}
-{{-   $ageRecipient = output "sh" "-c" "op read 'op://Dotfiles/Dotfiles Age Key/notesPlain' 2>/dev/null | age-keygen -y 2>/dev/null || true" | trim -}}
+{{-   if or (env "OP_SERVICE_ACCOUNT_TOKEN") (stdinIsATTY) -}}
+{{-     $ageRecipient = output "sh" "-c" "op read 'op://Dotfiles/Dotfiles Age Key/notesPlain' 2>/dev/null | age-keygen -y 2>/dev/null || true" | trim -}}
+{{-   end -}}
 {{- end -}}
 {{- $opAvailable := ne $ageRecipient "" -}}
 {{- $ageAvailable := $opAvailable -}}
+
+{{/* Auth mode: a service-account token (exported only in SSH sessions, see
+     dot_zshenv) makes chezmoi's onepasswordRead resolve headlessly. Local
+     interactive runs have no token -> default desktop (biometric) integration,
+     unchanged. A headless run with neither a token nor a TTY fails fast
+     instead of hanging on a prompt no one can answer. Placed before [age];
+     never between [data] and [[data.profiles]] (it would be swallowed). */}}
+{{- if env "OP_SERVICE_ACCOUNT_TOKEN" }}
+[onepassword]
+mode = "service"
+{{- else if not stdinIsATTY }}
+[onepassword]
+prompt = false
+{{- end }}
 
 {{- if $ageAvailable }}
 encryption = "age"

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -60,9 +60,14 @@ recipient = {{ $ageRecipient | quote }}
 brew_prefix = {{ $brew_prefix | quote }}
 ageAvailable = {{ $ageAvailable }}
 {{- if $opAvailable }}
-ssh_key = "{{- onepasswordRead "op://Dotfiles/ssh_key/public_key" -}}"
-work_ssh_key = "{{- onepasswordRead "op://Dotfiles/work_ssh_key/public_key" -}}"
-work_email = "{{- onepasswordRead "op://Dotfiles/work_ssh_key/email" -}}"
+{{/* Read via raw `op` (self-selects the service token, like the age line
+     above) — NOT chezmoi's onepasswordRead, whose [onepassword] mode is always
+     `account` during config render and hard-errors when a token is set. These
+     vars currently have no downstream consumers; candidate for removal once
+     confirmed unused. */}}
+ssh_key = "{{ output "sh" "-c" "op read 'op://Dotfiles/ssh_key/public_key' 2>/dev/null || true" | trim }}"
+work_ssh_key = "{{ output "sh" "-c" "op read 'op://Dotfiles/work_ssh_key/public_key' 2>/dev/null || true" | trim }}"
+work_email = "{{ output "sh" "-c" "op read 'op://Dotfiles/work_ssh_key/email' 2>/dev/null || true" | trim }}"
 onepassword_available = true
 {{- else }}
 ssh_key = ""

--- a/home/bin/executable_dots
+++ b/home/bin/executable_dots
@@ -236,7 +236,7 @@ cmd_doctor() {
   if command -v op >/dev/null 2>&1; then
     if op whoami >/dev/null 2>&1; then
       log_ok "1Password CLI signed in ($(op whoami 2>/dev/null | awk '/^Email:/ {print $2}'))"
-    elif op read 'op://Personal/Dotfiles Age Key/notesPlain' >/dev/null 2>&1; then
+    elif op read 'op://Dotfiles/Dotfiles Age Key/notesPlain' >/dev/null 2>&1; then
       log_ok "1Password CLI available via app integration (no token session)"
     else
       log_warn "1Password CLI installed but not reachable (unlock 1Password, or run 'op signin')"

--- a/home/bin/executable_dots
+++ b/home/bin/executable_dots
@@ -99,7 +99,7 @@ cmd_sync() {
   while IFS= read -r relpath; do
     [ -z "$relpath" ] && continue
     drifted_files+=("$HOME/$relpath")
-  done < <(chezmoi diff --recursive "${re_add_targets[@]}" 2>/dev/null \
+  done < <(chezmoi diff --init --recursive "${re_add_targets[@]}" 2>/dev/null \
            | grep -E '^diff --git a/' \
            | sed -E 's|^diff --git a/([^ ]+) b/.*|\1|')
 
@@ -176,7 +176,14 @@ cmd_apply() {
     chezmoi_flags+=(--dry-run)
   fi
 
-  log_info "chezmoi apply..."
+  # --init re-renders the config from .chezmoi.toml.tmpl against THIS session's
+  # env before applying. Required for the 1Password auth switch: chezmoi bakes
+  # [onepassword] mode at config-render time and only READS it on a plain apply.
+  # With --init, an SSH session (token set) bakes service mode (headless) and a
+  # local session (no token, TTY) bakes the default biometric mode. A bare
+  # `chezmoi apply` reuses the last-baked mode and errors if the session type
+  # changed. See docs/GOTCHAS.md.
+  log_info "chezmoi apply (--init re-renders config for this session)..."
   # Package install is handled by run_onchange_before_10-install-packages.sh.tmpl
   # inside `chezmoi apply`, content-hashed off the Brewfile. We do NOT also
   # call `brew bundle install` here — that would re-attempt failing MAS / cask
@@ -184,7 +191,7 @@ cmd_apply() {
   # items. If you manually `brew uninstall`ed something and want it back,
   # run `brew bundle install --file="$(chezmoi source-path)/Brewfile"`
   # or touch the Brewfile to re-trigger the run_onchange hash.
-  chezmoi apply "${chezmoi_flags[@]}"
+  chezmoi apply --init "${chezmoi_flags[@]}"
 
   if [ "$dry_run" = "0" ]; then
     log_info "brew bundle cleanup..."

--- a/home/bin/executable_dots
+++ b/home/bin/executable_dots
@@ -234,7 +234,16 @@ cmd_doctor() {
   echo
   log_info "== 1Password =="
   if command -v op >/dev/null 2>&1; then
-    if op whoami >/dev/null 2>&1; then
+    if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+      # Service-token mode (remote/SSH). Report VALIDITY, not mere presence: a
+      # revoked/expired/stale token leaves the var set but every op call fails.
+      if op read 'op://Dotfiles/Dotfiles Age Key/notesPlain' >/dev/null 2>&1; then
+        log_ok "1Password service-account token valid (Dotfiles vault reachable)"
+      else
+        log_warn "OP_SERVICE_ACCOUNT_TOKEN set but Dotfiles unreadable (token revoked/expired, or vault not provisioned)"
+        fail=1
+      fi
+    elif op whoami >/dev/null 2>&1; then
       log_ok "1Password CLI signed in ($(op whoami 2>/dev/null | awk '/^Email:/ {print $2}'))"
     elif op read 'op://Dotfiles/Dotfiles Age Key/notesPlain' >/dev/null 2>&1; then
       log_ok "1Password CLI available via app integration (no token session)"

--- a/home/dot_claude/private_dot_env.tmpl
+++ b/home/dot_claude/private_dot_env.tmpl
@@ -1,2 +1,2 @@
 {{- /* Claude Code env vars — resolved from 1Password at apply time. */ -}}
-{{- onepasswordRead "op://Personal/Claude Code env/notesPlain" -}}
+{{- onepasswordRead "op://Dotfiles/Claude Code env/notesPlain" -}}

--- a/home/dot_codex/private_auth.json.tmpl
+++ b/home/dot_codex/private_auth.json.tmpl
@@ -1,1 +1,1 @@
-{{- onepasswordRead "op://Personal/Codex auth/notesPlain" -}}
+{{- onepasswordRead "op://Dotfiles/Codex auth/notesPlain" -}}

--- a/home/dot_codex/private_config.toml.tmpl
+++ b/home/dot_codex/private_config.toml.tmpl
@@ -119,7 +119,7 @@ config_file = "{{ .chezmoi.homeDir }}/.codex/agents/gsd-verifier.toml"
 
 [mcp_servers.uidotsh]
 url = "https://ui.sh/mcp?agent=codex"
-http_headers = { Authorization = "Bearer {{ onepasswordRead "op://Personal/ui.sh MCP/notesPlain" }}" }
+http_headers = { Authorization = "Bearer {{ onepasswordRead "op://Dotfiles/ui.sh MCP/notesPlain" }}" }
 
 [mcp_servers.uidotsh.tools.uidotsh_fetch]
 approval_mode = "approve"

--- a/home/dot_cursor/private_mcp.json.tmpl
+++ b/home/dot_cursor/private_mcp.json.tmpl
@@ -13,7 +13,7 @@
         "ghcr.io/github/github-mcp-server"
       ],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "{{ onepasswordRead "op://Personal/GitHub PAT - cursor mcp/notesPlain" }}"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "{{ onepasswordRead "op://Dotfiles/GitHub PAT - cursor mcp/notesPlain" }}"
       }
     },
     "github-actions": {
@@ -22,7 +22,7 @@
         "{{ .chezmoi.homeDir }}/Code/personal/github-actions-mcp-server/dist/index.js"
       ],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "{{ onepasswordRead "op://Personal/GitHub PAT - cursor mcp/notesPlain" }}"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "{{ onepasswordRead "op://Dotfiles/GitHub PAT - cursor mcp/notesPlain" }}"
       }
     },
     "heroku": {
@@ -54,7 +54,7 @@
     "uidotsh": {
       "url": "https://ui.sh/mcp?agent=cursor",
       "headers": {
-        "Authorization": "Bearer {{ onepasswordRead "op://Personal/ui.sh MCP/notesPlain" }}"
+        "Authorization": "Bearer {{ onepasswordRead "op://Dotfiles/ui.sh MCP/notesPlain" }}"
       }
     }
   }

--- a/home/dot_zshenv
+++ b/home/dot_zshenv
@@ -19,6 +19,16 @@ export CODEDIR="$HOME/Code"
 # 1Password SSH Agent
 export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
 
+# 1Password service-account token — SSH sessions only.
+# Over SSH there's no reachable Touch ID, so export the service-account token
+# (materialized to a 0600 file by bootstrap) to let op/chezmoi resolve secrets
+# headlessly. Dual guard: SSH-only, and only the first shell pays the read
+# (children inherit via the environment). Local shells never carry the token,
+# so they fall back to biometric desktop integration.
+if [[ -n "$SSH_CONNECTION" && -z "$OP_SERVICE_ACCOUNT_TOKEN" && -r "$HOME/.config/op/token" ]]; then
+  export OP_SERVICE_ACCOUNT_TOKEN="$(<"$HOME/.config/op/token")"
+fi
+
 # Zim configuration
 export ZIM_HOME="${XDG_CACHE_HOME}/zim"
 export ZIM_CONFIG_FILE="${XDG_CONFIG_HOME}/zsh/.zimrc"

--- a/home/dot_zshenv
+++ b/home/dot_zshenv
@@ -24,9 +24,14 @@ export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/
 # (materialized to a 0600 file by bootstrap) to let op/chezmoi resolve secrets
 # headlessly. Dual guard: SSH-only, and only the first shell pays the read
 # (children inherit via the environment). Local shells never carry the token,
-# so they fall back to biometric desktop integration.
-if [[ -n "$SSH_CONNECTION" && -z "$OP_SERVICE_ACCOUNT_TOKEN" && -r "$HOME/.config/op/token" ]]; then
-  export OP_SERVICE_ACCOUNT_TOKEN="$(<"$HOME/.config/op/token")"
+# so they fall back to biometric desktop integration. The token is a long-lived
+# bearer, so refuse to load it from anything looser than 0600 (perm-drift guard).
+if [[ -n "$SSH_CONNECTION" && -z "$OP_SERVICE_ACCOUNT_TOKEN" && -f "$HOME/.config/op/token" ]]; then
+  if [[ "$(stat -f '%Lp' "$HOME/.config/op/token" 2>/dev/null)" == "600" ]]; then
+    export OP_SERVICE_ACCOUNT_TOKEN="$(<"$HOME/.config/op/token")"
+  else
+    print -ru2 -- "warning: ~/.config/op/token is not 0600; refusing to load the 1Password service-account token (rotate it if it may have been exposed)."
+  fi
 fi
 
 # Zim configuration

--- a/home/private_dot_ssh/config.tmpl
+++ b/home/private_dot_ssh/config.tmpl
@@ -24,12 +24,15 @@ Host github.com-work
   IdentityAgent none
   IdentityFile ~/.ssh/work_id
 
+# Tailnet hosts: IPs sourced from 1Password (op://Dotfiles/Tailscale Hosts) so
+# the public source doesn't carry infra topology. Rendered ~/.ssh/config has the
+# literal IPs; resolved at apply time (service token remote, biometric local).
 Host ezra
-  HostName 100.83.244.117
+  HostName {{ onepasswordRead "op://Dotfiles/Tailscale Hosts/ezra" }}
   User ezra
 
 Host silas
-  HostName 100.76.142.125
+  HostName {{ onepasswordRead "op://Dotfiles/Tailscale Hosts/silas" }}
   User root
   SetEnv TERM=xterm-256color
   LocalForward 9119 127.0.0.1:9119

--- a/home/private_dot_ssh/id.pub.tmpl
+++ b/home/private_dot_ssh/id.pub.tmpl
@@ -1,1 +1,1 @@
-{{ onepasswordRead "op://Personal/4ytcjbe2ui6iz5sjfe7fn54jea/public_key" }}
+{{ onepasswordRead "op://Dotfiles/4ytcjbe2ui6iz5sjfe7fn54jea/public_key" }}

--- a/home/private_dot_ssh/id.pub.tmpl
+++ b/home/private_dot_ssh/id.pub.tmpl
@@ -1,1 +1,1 @@
-{{ onepasswordRead "op://Dotfiles/4ytcjbe2ui6iz5sjfe7fn54jea/public_key" }}
+{{ onepasswordRead "op://Dotfiles/ssh_key/public_key" }}

--- a/home/private_dot_ssh/private_id.tmpl
+++ b/home/private_dot_ssh/private_id.tmpl
@@ -1,1 +1,1 @@
-{{ onepasswordRead "op://Dotfiles/4ytcjbe2ui6iz5sjfe7fn54jea/private_key?ssh-format=openssh" }}
+{{ onepasswordRead "op://Dotfiles/ssh_key/private_key?ssh-format=openssh" }}

--- a/home/private_dot_ssh/private_id.tmpl
+++ b/home/private_dot_ssh/private_id.tmpl
@@ -1,1 +1,1 @@
-{{ onepasswordRead "op://Personal/4ytcjbe2ui6iz5sjfe7fn54jea/private_key?ssh-format=openssh" }}
+{{ onepasswordRead "op://Dotfiles/4ytcjbe2ui6iz5sjfe7fn54jea/private_key?ssh-format=openssh" }}

--- a/home/private_dot_ssh/private_work_id.tmpl
+++ b/home/private_dot_ssh/private_work_id.tmpl
@@ -1,1 +1,1 @@
-{{ onepasswordRead "op://Dotfiles/orsplwhcmkbfmxdwbf6udvpjvu/private_key?ssh-format=openssh" }}
+{{ onepasswordRead "op://Dotfiles/work_ssh_key/private_key?ssh-format=openssh" }}

--- a/home/private_dot_ssh/private_work_id.tmpl
+++ b/home/private_dot_ssh/private_work_id.tmpl
@@ -1,1 +1,1 @@
-{{ onepasswordRead "op://Personal/orsplwhcmkbfmxdwbf6udvpjvu/private_key?ssh-format=openssh" }}
+{{ onepasswordRead "op://Dotfiles/orsplwhcmkbfmxdwbf6udvpjvu/private_key?ssh-format=openssh" }}

--- a/home/private_dot_ssh/work_id.pub.tmpl
+++ b/home/private_dot_ssh/work_id.pub.tmpl
@@ -1,1 +1,1 @@
-{{ onepasswordRead "op://Dotfiles/orsplwhcmkbfmxdwbf6udvpjvu/public_key" }}
+{{ onepasswordRead "op://Dotfiles/work_ssh_key/public_key" }}

--- a/home/private_dot_ssh/work_id.pub.tmpl
+++ b/home/private_dot_ssh/work_id.pub.tmpl
@@ -1,1 +1,1 @@
-{{ onepasswordRead "op://Personal/orsplwhcmkbfmxdwbf6udvpjvu/public_key" }}
+{{ onepasswordRead "op://Dotfiles/orsplwhcmkbfmxdwbf6udvpjvu/public_key" }}


### PR DESCRIPTION
## What

Make `op`-backed commands (chiefly `chezmoi apply`) work **headless when remote** — no Touch ID — while keeping local interactive auth on biometric. Fixes the long-standing pain where running `chezmoi apply` over SSH (e.g. from an iPad via Tailscale/Termius) fired a 1Password fingerprint prompt on the *physical* Mac and timed out.

## How

Auth is split by context, extending the same philosophy as the git-signing fix (`docs/1password-ssh-signing-rca.md` §10):

- **Isolated vault** — all chezmoi-read secrets moved from the Personal vault to a dedicated, read-only `Dotfiles` vault (1Password service accounts categorically can't read the Personal vault).
- **Conditional mode** — `.chezmoi.toml.tmpl` templates `[onepassword] mode = "service"` when `OP_SERVICE_ACCOUNT_TOKEN` is present, else the default biometric integration.
- **SSH-gated token** — `dot_zshenv` exports the token (from a `0600` `~/.config/op/token` cache) **only when `$SSH_CONNECTION` is set**, so the local Mac's ambient env never holds it.
- **`dots apply --init`** — chezmoi bakes the auth mode at config-render time, so `dots apply`/`dots sync` now `--init` to re-render the config each run and track the current session (service over SSH, biometric locally).

Also moves the Tailscale host IPs out of the public source into 1Password (no infra topology in a public repo), and teaches `dots doctor` to report token *validity*, not mere presence.

## Verified

- ✅ Headless `dots apply` over SSH from an iPad (the original failure case) — completes, no prompt.
- ✅ Local biometric path unchanged.
- ✅ Service token, vault grant, `?ssh-format=openssh` reads, Tailscale lookups, and the config-template mechanism all confirmed live on the M5.

## Notes / decisions

- Token storage is a `0600` file (mirrors the age-key cache); macOS Keychain was rejected because first access over SSH can raise an unanswerable GUI auth dialog.
- Item UUIDs change on a 1Password vault move, so SSH-key items are referenced by **name**; service-account vault grants are immutable.
- Config-template op reads use raw `op` (self-selects the token) — chezmoi's `onepasswordRead` defaults to `account` mode during config render and hard-errors when a token is set.
- Deferred follow-ups: gate `SSH_AUTH_SOCK` for non-GitHub remote SSH; reduce per-apply SSH-key re-materialization churn.
