### PR TITLE
fix(nvim): C-h reaches tmux from snacks explorer

### DIFF
--- a/home/dot_config/nvim/lua/plugins/editor.lua
+++ b/home/dot_config/nvim/lua/plugins/editor.lua
@@ -1,19 +1,24 @@
--- Inside the snacks.nvim Explorer, <C-h> can't reach the left tmux pane the way
--- it does from a normal buffer. The Explorer is a split-layout picker with a
--- hidden "root" window: vim-tmux-navigator's <C-h> runs `wincmd h`, which lands
--- in that root, and snacks immediately bounces focus back into the editor with
--- `wincmd l`. The window number changed, so vim-tmux-navigator concludes it
--- moved within Neovim and never forwards the keystroke to tmux. (<C-l/j/k> don't
--- pass through the root, so they already work.) Fix: in the Explorer only, send
--- <C-h> straight to tmux, bypassing the `wincmd h` that gets bounced. The
--- Explorer is pinned leftmost, so "left" is unambiguously the tmux pane beside it.
+-- <C-h> from the snacks.nvim Explorer can't reach the left tmux pane the way it
+-- does from a normal buffer. The Explorer is a split-layout picker with a hidden
+-- "root" window: vim-tmux-navigator's <C-h> runs `wincmd h`, lands in that root,
+-- and snacks bounces focus back into the editor with `wincmd l`. The window
+-- number changed, so the navigator concludes it moved within Neovim and never
+-- forwards to tmux. (<C-l/j/k> don't pass through the root, so they already work.)
+--
+-- Fix: rebind <C-h> on the picker list buffer to go straight to the left tmux
+-- pane, bypassing the bounced `wincmd h`. This attaches to every picker's list
+-- window, not just the Explorer — but that's harmless: from any list-window left
+-- edge the normal navigator would forward to tmux anyway, so the result matches.
+-- The augroup's clear=true keeps a re-source (`:Lazy reload`) from stacking
+-- duplicate autocmds (and thus duplicate buffer-local maps).
 vim.api.nvim_create_autocmd("FileType", {
+  group = vim.api.nvim_create_augroup("snacks_picker_tmux_nav", { clear = true }),
   pattern = "snacks_picker_list",
   callback = function(ev)
     if vim.env.TMUX then
       vim.keymap.set("n", "<C-h>", function()
         vim.fn.system("tmux select-pane -L")
-      end, { buffer = ev.buf, desc = "Tmux navigate left (snacks explorer)" })
+      end, { buffer = ev.buf, desc = "Tmux navigate left (snacks picker list)" })
     end
   end,
 })

--- a/home/dot_config/nvim/lua/plugins/editor.lua
+++ b/home/dot_config/nvim/lua/plugins/editor.lua
@@ -1,3 +1,23 @@
+-- Inside the snacks.nvim Explorer, <C-h> can't reach the left tmux pane the way
+-- it does from a normal buffer. The Explorer is a split-layout picker with a
+-- hidden "root" window: vim-tmux-navigator's <C-h> runs `wincmd h`, which lands
+-- in that root, and snacks immediately bounces focus back into the editor with
+-- `wincmd l`. The window number changed, so vim-tmux-navigator concludes it
+-- moved within Neovim and never forwards the keystroke to tmux. (<C-l/j/k> don't
+-- pass through the root, so they already work.) Fix: in the Explorer only, send
+-- <C-h> straight to tmux, bypassing the `wincmd h` that gets bounced. The
+-- Explorer is pinned leftmost, so "left" is unambiguously the tmux pane beside it.
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "snacks_picker_list",
+  callback = function(ev)
+    if vim.env.TMUX then
+      vim.keymap.set("n", "<C-h>", function()
+        vim.fn.system("tmux select-pane -L")
+      end, { buffer = ev.buf, desc = "Tmux navigate left (snacks explorer)" })
+    end
+  end,
+})
+
 return {
   -- Seamless C-h/j/k/l navigation across Neovim splits AND tmux panes.
   -- The tmux half lives in ~/.config/tmux/tmux.conf (inline bind-key lines).


### PR DESCRIPTION
## What

In the snacks **Explorer**, `<C-h>` wrapped to the editor buffer instead of moving to the left tmux pane. `<C-l/j/k>` worked fine.

## Why

The Explorer is a split-layout picker with a hidden *root* window. vim-tmux-navigator's `<C-h>` runs `wincmd h`, which lands in that root; snacks then bounces focus back into the editor with `wincmd l`. Because the window number changed, the navigator concludes it moved *within* Neovim and never forwards the keystroke to `tmux select-pane -L`. `<C-l/j/k>` don't pass through the root, so they were unaffected.

## Fix

A buffer-local `<C-h>` on the explorer's `snacks_picker_list` filetype that talks to tmux directly, bypassing the bounced `wincmd h`. The Explorer is pinned leftmost, so "left" is unambiguously the tmux pane beside it. Guarded by `$TMUX` so it's a no-op when Neovim runs outside tmux. The global navigator keymaps are untouched.

## Verified

Restarted nvim → opened Explorer → `<C-h>` now moves to the left tmux pane; `<C-l>` still moves right into the editor. Confirmed live on the M5.