### PR TITLE
fix(ci): grant Claude Code Action write perms so reviews can post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,14 +19,14 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Problem

The Claude Code Review action ran on every PR but **never posted a review/comment**.

## Root cause

`claude-code-action` mints a short-lived GitHub App token that's **scoped down to the workflow's declared `permissions:` block** (per the action's security model — the token "cannot perform actions beyond the configured permissions"). Both workflows shipped with read-only permissions:

```yaml
pull-requests: read
issues: read
```

So Claude could read the diff and run the review, but every API call to **post** it was denied. The run exited `success` with `permission_denials_count: 17` — a silent failure (verified in run logs on a prior PR).

The Claude GitHub **App** having Read/Write doesn't help: the workflow block caps the minted token regardless.

## Fix

Match Anthropic's canonical example workflows (`examples/pr-review-comprehensive.yml`, `examples/claude.yml`):

- **claude-code-review.yml** — `pull-requests` + `issues` → `write`
- **claude.yml** — `contents` + `pull-requests` + `issues` → `write`
- Bump `actions/checkout` v4 → v6 (clears the Node 20 deprecation warning seen in run logs)

No `run:` step consumes untrusted event input, so raising write scope introduces no injection surface.

## Verify

After merge, re-trigger the review on an open PR (e.g. push to #9) → a review comment should land. `pull_request` workflows use the base-branch (main) YAML, so the fix takes effect once merged.